### PR TITLE
allow late migration

### DIFF
--- a/contracts/DeprecateERC20.sol
+++ b/contracts/DeprecateERC20.sol
@@ -6,6 +6,7 @@ import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.s
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 // ============ Internal Imports ============
 import {IPartyToken} from "./interfaces/IPartyToken.sol";
+import "hardhat/console.sol";
 
 /*
 DeprecateERC20
@@ -39,6 +40,8 @@ contract DeprecateERC20 is Initializable {
 
     function initialize(address _newToken) external initializer {
         newToken = IPartyToken(_newToken);
+        newToken.approve(address(this), 2**256 - 1);
+        console.log("approving");
     }
 
     // ======== External Functions =========
@@ -54,8 +57,9 @@ contract DeprecateERC20 is Initializable {
         uint256 _oldBalance = oldToken.balanceOf(_tokenHolder);
         // send total balance of old token to burn address
         oldToken.transferFrom(_tokenHolder, address(0), _oldBalance);
+        console.log("Old balance", _oldBalance);
         // send balance of new token to caller
-        newToken.lockupTransfer(_tokenHolder, _oldBalance * exchangeRate);
+        newToken.transferFrom(address(this), _tokenHolder, _oldBalance * exchangeRate);
         // update total & emit event
         totalMigrated += _oldBalance;
         emit Migrated(_tokenHolder, _oldBalance);

--- a/contracts/DeprecateERC20.sol
+++ b/contracts/DeprecateERC20.sol
@@ -55,7 +55,6 @@ contract DeprecateERC20 is Initializable {
         uint256 _oldBalance = oldToken.balanceOf(_tokenHolder);
         // send total balance of old token to burn address
         oldToken.transferFrom(_tokenHolder, address(0), _oldBalance);
-        console.log("Old balance", _oldBalance);
         // send balance of new token to caller
         newToken.transferFrom(address(this), _tokenHolder, _oldBalance * exchangeRate);
         // update total & emit event

--- a/contracts/DeprecateERC20.sol
+++ b/contracts/DeprecateERC20.sol
@@ -6,7 +6,6 @@ import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.s
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 // ============ Internal Imports ============
 import {IPartyToken} from "./interfaces/IPartyToken.sol";
-import "hardhat/console.sol";
 
 /*
 DeprecateERC20
@@ -41,7 +40,6 @@ contract DeprecateERC20 is Initializable {
     function initialize(address _newToken) external initializer {
         newToken = IPartyToken(_newToken);
         newToken.approve(address(this), 2**256 - 1);
-        console.log("approving");
     }
 
     // ======== External Functions =========

--- a/contracts/DeprecateERC20.sol
+++ b/contracts/DeprecateERC20.sol
@@ -39,7 +39,6 @@ contract DeprecateERC20 is Initializable {
 
     function initialize(address _newToken) external initializer {
         newToken = IPartyToken(_newToken);
-        newToken.approve(address(this), 2**256 - 1);
     }
 
     // ======== External Functions =========
@@ -56,7 +55,7 @@ contract DeprecateERC20 is Initializable {
         // send total balance of old token to burn address
         oldToken.transferFrom(_tokenHolder, address(0), _oldBalance);
         // send balance of new token to caller
-        newToken.transferFrom(address(this), _tokenHolder, _oldBalance * exchangeRate);
+        newToken.transfer(_tokenHolder, _oldBalance * exchangeRate);
         // update total & emit event
         totalMigrated += _oldBalance;
         emit Migrated(_tokenHolder, _oldBalance);

--- a/contracts/PartyToken.sol
+++ b/contracts/PartyToken.sol
@@ -66,7 +66,7 @@ contract PartyToken is ERC20VotesComp {
      * - `sender` must have a balance of at least `amount`.
      * - the caller must have allowance for ``sender``'s tokens of at least
      * `amount`.
-     * - the lockup period cannot be active unless being called from the deprecation contract
+     * - the lockup period cannot be active
      */
     function transferFrom(
         address sender,

--- a/contracts/PartyToken.sol
+++ b/contracts/PartyToken.sol
@@ -73,7 +73,7 @@ contract PartyToken is ERC20VotesComp {
         address recipient,
         uint256 amount
     ) public override returns (bool) {
-        require(!lockupPeriod || msg.sender == deprecationContract, "lockup period");
+        require(!lockupPeriod, "lockup period");
         super.transferFrom(sender, recipient, amount);
     }
 

--- a/contracts/interfaces/IPartyToken.sol
+++ b/contracts/interfaces/IPartyToken.sol
@@ -1,5 +1,7 @@
 pragma solidity 0.8.5;
 
-interface IPartyToken {
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+interface IPartyToken is IERC20{
     function lockupTransfer(address recipient, uint256 amount) external returns (bool);
 }

--- a/test/PartyToken.test.js
+++ b/test/PartyToken.test.js
@@ -36,13 +36,13 @@ describe('DeprecationContract', async () => {
     });
 
     it('Cannot transfer during lockup', async () => {
-        await expect(newToken.transfer(user.address, eth(20))).to.be.revertedWith("Pausable: paused");
+        await expect(newToken.transfer(user.address, eth(20))).to.be.revertedWith("lockup period");
 
         const data = encodeData(newToken, 'transfer', [signers[0].address, eth(20)]);
         await expect(user.sendTransaction({
             to: newToken.address,
             data,
-        })).to.be.revertedWith("Pausable: paused");
+        })).to.be.revertedWith("lockup period");
     });
 
     it('Cannot transferFrom during lockup', async () => {
@@ -51,7 +51,7 @@ describe('DeprecationContract', async () => {
             to: newToken.address,
             data,
         });
-        await expect(newToken.transferFrom(user.address, signers[0].address, eth(20))).to.be.revertedWith("Pausable: paused");
+        await expect(newToken.transferFrom(user.address, signers[0].address, eth(20))).to.be.revertedWith("lockup period");
     });
 
     it('CAN lockupTransfer during lockup', async () => {
@@ -63,7 +63,7 @@ describe('DeprecationContract', async () => {
     });
 
     it('Cannot call end lockup twice', async () => {
-        await expect(newToken.endLockup()).to.be.revertedWith("Pausable: not paused");
+        await expect(newToken.endLockup()).to.be.revertedWith("already unlocked");
     });
 
     it('CAN transfer after lockup', async () => {


### PR DESCRIPTION
Proposal to allow tokens to be migrated after the lockup period, in order to let us decouple the lockup period from 100% of token holders migrating.